### PR TITLE
Minor cleanup of semicolons and use Vector.newBuilder for improved performance

### DIFF
--- a/src/org.velvia/PackingUtils.scala
+++ b/src/org.velvia/PackingUtils.scala
@@ -127,13 +127,13 @@ trait PackingUtils {
   protected def unpackMap(size: Int, in: DataInputStream, options: Int): Map[_, _] = {
     if (size < 0)
       throw new InvalidMsgPackDataException("Map to unpack too large for Java (more than 2^31 elements)!")
-    val map = collection.immutable.HashMap.newBuilder[Any, Any]
+    var map = collection.immutable.HashMap.empty[Any, Any]
     var i = 0
     while (i < size) {
-      map += unpack(in, options) -> unpack(in, options)
+      map = map.updated(unpack(in, options), unpack(in, options))
       i += 1
     }
-    map.result
+    map
   }
 
   protected def unpackRaw(size: Int, in: DataInputStream, options: Int): Any = {


### PR DESCRIPTION
``` scala
Welcome to Scala version 2.9.3 (Java HotSpot(TM) 64-Bit Server VM, Java 1.6.0_41).
Type in expressions to have them evaluated.
Type :help for more information.

scala> import com.twitter.util.Time
import com.twitter.util.Time

scala> import scala.collection._
import scala.collection._

scala> var vector = immutable.Vector.empty[Int]
vector: scala.collection.immutable.Vector[Int] = Vector()

scala> println(Time.measure { (0 to 50000000).foreach { vector :+= _ } }.inMillis)
7395

scala> val b = Vector.newBuilder[Int]
b: scala.collection.mutable.Builder[Int,scala.collection.immutable.Vector[Int]] = scala.collection.immutable.VectorBuilder@b06cf66

scala> println(Time.measure { (0 to 50000000).foreach { b += _ }; b.result }.inMillis)
2855

scala>
```
