### PR TITLE
Added Case Class codecs, Tuple codecs and Transform codecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import bintray.Plugin.bintrayPublishSettings
 
 name := "msgpack4s"
 
-val commonSettings = Seq(scalaVersion := "2.11.7", organization := "org.velvia")
+val commonSettings = Seq(scalaVersion := "2.11.7", organization := "org.velvia", crossScalaVersions := Seq("2.10.4", "2.11.7"))
 
 unmanagedSourceDirectories in Compile <++= Seq(baseDirectory(_ / "src" )).join
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import bintray.Plugin.bintrayPublishSettings
+
 name := "msgpack4s"
 
 val commonSettings = Seq(scalaVersion := "2.11.7", organization := "org.velvia")
@@ -19,6 +21,8 @@ lazy val playJson   = "com.typesafe.play" %% "play-json" % "2.4.1"
 libraryDependencies ++= Seq(rojomaJson % "provided",
                             json4s     % "provided",
                             playJson   % "provided")
+
+Seq(bintrayPublishSettings: _*)
 
 licenses += ("Apache-2.0", url("http://choosealicense.com/licenses/apache/"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,11 @@ import bintray.Plugin.bintrayPublishSettings
 
 name := "msgpack4s"
 
-val commonSettings = Seq(scalaVersion := "2.11.7", organization := "org.velvia", crossScalaVersions := Seq("2.10.4", "2.11.7"))
+val commonSettings = Seq(
+  scalaVersion := "2.11.7",
+  organization := "org.velvia",
+  crossScalaVersions := Seq("2.10.4", "2.11.7")
+)
 
 unmanagedSourceDirectories in Compile <++= Seq(baseDirectory(_ / "src" )).join
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 name := "msgpack4s"
 
-organization := "org.velvia"
-
-scalaVersion := "2.11.7"
+val commonSettings = Seq(scalaVersion := "2.11.7", organization := "org.velvia")
 
 unmanagedSourceDirectories in Compile <++= Seq(baseDirectory(_ / "src" )).join
 
@@ -24,10 +22,11 @@ libraryDependencies ++= Seq(rojomaJson % "provided",
 
 licenses += ("Apache-2.0", url("http://choosealicense.com/licenses/apache/"))
 
-lazy val msgpack4s = (project in file("."))
+lazy val msgpack4s = (project in file(".")).settings(commonSettings: _*)
 
 lazy val jmh = (project in file("jmh")).dependsOn(msgpack4s)
-                        .settings(jmhSettings:_*)
+                        .settings(commonSettings: _*)
+                        .settings(jmhSettings: _*)
                         .settings(libraryDependencies += rojomaJson)
                         .settings(libraryDependencies += json4s)
                         .settings(libraryDependencies += commonsIo)

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,7 @@ name := "msgpack4s"
 
 organization := "org.velvia"
 
-scalaVersion := "2.10.4"
-
-crossScalaVersions := Seq("2.10.4", "2.11.5")
+scalaVersion := "2.11.7"
 
 unmanagedSourceDirectories in Compile <++= Seq(baseDirectory(_ / "src" )).join
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import bintray.Plugin.bintrayPublishSettings
-
 name := "msgpack4s"
 
 organization := "org.velvia"
@@ -25,8 +23,6 @@ lazy val playJson   = "com.typesafe.play" %% "play-json" % "2.4.1"
 libraryDependencies ++= Seq(rojomaJson % "provided",
                             json4s     % "provided",
                             playJson   % "provided")
-
-Seq(bintrayPublishSettings: _*)
 
 licenses += ("Apache-2.0", url("http://choosealicense.com/licenses/apache/"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,10 @@
+resolvers += Resolver.url(
+  "bintray-sbt-plugin-releases",
+    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
+        Resolver.ivyStylePatterns)
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
+
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.12")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,1 @@
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-        Resolver.ivyStylePatterns)
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
-
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.12")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")

--- a/src/org.velvia/MsgPackUtils.scala
+++ b/src/org.velvia/MsgPackUtils.scala
@@ -1,5 +1,6 @@
 package org.velvia
 
+import scala.language.implicitConversions
 import java.io.DataInputStream
 
 /**

--- a/src/org.velvia/msgpack/CaseClassCodecs.scala
+++ b/src/org.velvia/msgpack/CaseClassCodecs.scala
@@ -1,0 +1,79 @@
+package org.velvia.msgpack
+
+import java.io.{DataInputStream => DIS, DataOutputStream}
+
+import org.velvia.msgpack.TupleCodecs.{TupleCodec4, TupleCodec3, TupleCodec2}
+
+object CaseClassCodecs {
+
+  class CaseClassCodec1[T, A](
+    apply: A => T,
+    unapply: T => Option[A]
+  )(implicit K: Codec[A]) extends Codec[T] {
+
+    private val codec1 = implicitly[Codec[A]]
+
+    override def pack(out: DataOutputStream, item: T): Unit = {
+      out.write(0x01 | Format.MP_FIXARRAY)
+      codec1.pack(out, unapply(item).get)
+    }
+    val unpackFuncMap = FastByteMap[UnpackFunc](
+      (0x01 | Format.MP_FIXARRAY).toByte -> { in: DIS =>
+        val r1 = codec1.unpack(in)
+        apply(r1)
+      }
+    )
+  }
+
+
+  class CaseClassCodec2[T, A1, A2](
+    apply: (A1, A2) => T,
+    unapply: T => Option[(A1, A2)]
+  )(
+    implicit K1: Codec[A1],
+    K2: Codec[A2]
+  ) extends Codec[T] {
+    val codec = new TupleCodec2[A1, A2]
+    val _apply: ((A1, A2)) => T = Function.tupled(apply)
+
+    override def pack(out: DataOutputStream, item: T): Unit = {
+      codec.pack(out, unapply(item).get)
+    }
+    val unpackFuncMap = codec.unpackFuncMap.mapValues(_.andThen(_apply))
+  }
+
+  class CaseClassCodec3[T, A1, A2, A3](
+    apply: (A1, A2, A3) => T,
+    unapply: T => Option[(A1, A2, A3)]
+  )(
+    implicit K1: Codec[A1],
+    K2: Codec[A2],
+    K3: Codec[A3]
+  ) extends Codec[T] {
+    val codec = new TupleCodec3[A1, A2, A3]
+    val _apply = Function.tupled(apply)
+
+    override def pack(out: DataOutputStream, item: T): Unit = {
+      codec.pack(out, unapply(item).get)
+    }
+    val unpackFuncMap = codec.unpackFuncMap.mapValues(_.andThen(_apply))
+  }
+
+  class CaseClassCodec4[T, A1, A2, A3, A4](
+    apply: (A1, A2, A3, A4) => T,
+    unapply: T => Option[(A1, A2, A3, A4)]
+  )(
+    implicit K1: Codec[A1],
+    K2: Codec[A2],
+    K3: Codec[A3],
+    K4: Codec[A4]
+  ) extends Codec[T] {
+    val codec = new TupleCodec4[A1, A2, A3, A4]
+    val _apply = Function.tupled(apply)
+
+    override def pack(out: DataOutputStream, item: T): Unit = {
+      codec.pack(out, unapply(item).get)
+    }
+    val unpackFuncMap = codec.unpackFuncMap.mapValues(_.andThen(_apply))
+  }
+}

--- a/src/org.velvia/msgpack/CollectionCodecs.scala
+++ b/src/org.velvia/msgpack/CollectionCodecs.scala
@@ -46,4 +46,13 @@ object CollectionCodecs {
       (MP_FIXMAP | len).toByte -> { in: DIS => unpackMap(len, in)(keyCodec, valCodec) }
     }
   }
+
+  class SetCodec[T: Codec] extends Codec[Set[T]] {
+    private val seqCodec = new SeqCodec[T]
+    def pack(out: DataOutputStream, s: Set[T]): Unit = {
+      seqCodec.pack(out, s.toSeq)
+    }
+    val unpackFuncMap = seqCodec.unpackFuncMap.mapValues(_.andThen(_.toSet))
+  }
+
 }

--- a/src/org.velvia/msgpack/TransformCodecs.scala
+++ b/src/org.velvia/msgpack/TransformCodecs.scala
@@ -1,0 +1,26 @@
+package org.velvia.msgpack
+
+import java.io.DataOutputStream
+
+
+object TransformCodecs {
+
+  class TransformCodec[A, B: Codec](
+    forward: A => B,
+    backward: B => A
+  ) extends Codec[A] {
+
+    private val codec1 = implicitly[Codec[B]]
+
+    override def pack(out: DataOutputStream, item: A): Unit =
+      codec1.pack(out, forward(item))
+
+    val unpackFuncMap = {
+      val things = codec1.unpackFuncMap.things map { case (byte, func) =>
+        byte -> func.andThen(backward)
+      }
+
+      FastByteMap[UnpackFunc](things: _*)
+    }
+  }
+}

--- a/src/org.velvia/msgpack/TransformCodecs.scala
+++ b/src/org.velvia/msgpack/TransformCodecs.scala
@@ -5,6 +5,14 @@ import java.io.DataOutputStream
 
 object TransformCodecs {
 
+  /** Defines a codec for `A` given one for `B` and a bijection `A` <=> `B`.
+    *
+    * An example would be (de)serializing a `Date` by storing its timestamp,
+    * which is just a `Long`. This would look like:
+    *
+    *     import java.util.Date
+    *     val c: Codec[Date] = new TransformCodec[Date, Long](_.getTime, new Date(_))
+    */
   class TransformCodec[A, B: Codec](
     forward: A => B,
     backward: B => A

--- a/src/org.velvia/msgpack/TupleCodecs.scala
+++ b/src/org.velvia/msgpack/TupleCodecs.scala
@@ -1,0 +1,78 @@
+package org.velvia.msgpack
+
+import java.io.{DataInputStream => DIS, DataOutputStream}
+
+object TupleCodecs {
+  class TupleCodec2[A1: Codec, A2: Codec] extends Codec[(A1, A2)] {
+
+    private val codec1 = implicitly[Codec[A1]]
+    private val codec2 = implicitly[Codec[A2]]
+
+    def pack(out: DataOutputStream, item: (A1, A2)): Unit = {
+      out.write(0x02 | Format.MP_FIXARRAY)
+      codec1.pack(out, item._1)
+      codec2.pack(out, item._2)
+    }
+
+    val unpackFuncMap = FastByteMap[UnpackFunc](
+      (0x02 | Format.MP_FIXARRAY).toByte -> { in: DIS =>
+        val r1 = codec1.unpack(in)
+        val r2 = codec2.unpack(in)
+        (r1, r2)
+      }
+    )
+  }
+
+  class TupleCodec3[A1: Codec, A2: Codec, A3: Codec]
+    extends Codec[(A1, A2, A3)] {
+
+    private val codec1 = implicitly[Codec[A1]]
+    private val codec2 = implicitly[Codec[A2]]
+    private val codec3 = implicitly[Codec[A3]]
+
+    def pack(out: DataOutputStream, item: (A1, A2, A3)): Unit = {
+      out.write(0x02 | Format.MP_FIXARRAY)
+      codec1.pack(out, item._1)
+      codec2.pack(out, item._2)
+      codec3.pack(out, item._3)
+    }
+
+    val unpackFuncMap = FastByteMap[UnpackFunc](
+      (0x02 | Format.MP_FIXARRAY).toByte -> { in: DIS =>
+        val r1 = codec1.unpack(in)
+        val r2 = codec2.unpack(in)
+        val r3 = codec3.unpack(in)
+        (r1, r2, r3)
+      }
+    )
+  }
+
+  class TupleCodec4[A1: Codec, A2: Codec, A3: Codec, A4: Codec]
+    extends Codec[(A1, A2, A3, A4)] {
+
+    private val codec1 = implicitly[Codec[A1]]
+    private val codec2 = implicitly[Codec[A2]]
+    private val codec3 = implicitly[Codec[A3]]
+    private val codec4 = implicitly[Codec[A4]]
+
+    def pack(out: DataOutputStream, item: (A1, A2, A3, A4)): Unit = {
+      out.write(0x02 | Format.MP_FIXARRAY)
+      codec1.pack(out, item._1)
+      codec2.pack(out, item._2)
+      codec3.pack(out, item._3)
+      codec4.pack(out, item._4)
+    }
+
+    val unpackFuncMap = FastByteMap[UnpackFunc](
+      (0x02 | Format.MP_FIXARRAY).toByte -> { in: DIS =>
+        val r1 = codec1.unpack(in)
+        val r2 = codec2.unpack(in)
+        val r3 = codec3.unpack(in)
+        val r4 = codec4.unpack(in)
+        (r1, r2, r3, r4)
+      }
+    )
+  }
+
+  // TODO: add TupleCodec5, TupleCodec6 ... and so on
+}

--- a/src/org.velvia/msgpack/TupleCodecs.scala
+++ b/src/org.velvia/msgpack/TupleCodecs.scala
@@ -31,14 +31,14 @@ object TupleCodecs {
     private val codec3 = implicitly[Codec[A3]]
 
     def pack(out: DataOutputStream, item: (A1, A2, A3)): Unit = {
-      out.write(0x02 | Format.MP_FIXARRAY)
+      out.write(0x03 | Format.MP_FIXARRAY)
       codec1.pack(out, item._1)
       codec2.pack(out, item._2)
       codec3.pack(out, item._3)
     }
 
     val unpackFuncMap = FastByteMap[UnpackFunc](
-      (0x02 | Format.MP_FIXARRAY).toByte -> { in: DIS =>
+      (0x03 | Format.MP_FIXARRAY).toByte -> { in: DIS =>
         val r1 = codec1.unpack(in)
         val r2 = codec2.unpack(in)
         val r3 = codec3.unpack(in)
@@ -56,7 +56,7 @@ object TupleCodecs {
     private val codec4 = implicitly[Codec[A4]]
 
     def pack(out: DataOutputStream, item: (A1, A2, A3, A4)): Unit = {
-      out.write(0x02 | Format.MP_FIXARRAY)
+      out.write(0x04 | Format.MP_FIXARRAY)
       codec1.pack(out, item._1)
       codec2.pack(out, item._2)
       codec3.pack(out, item._3)
@@ -64,7 +64,7 @@ object TupleCodecs {
     }
 
     val unpackFuncMap = FastByteMap[UnpackFunc](
-      (0x02 | Format.MP_FIXARRAY).toByte -> { in: DIS =>
+      (0x04 | Format.MP_FIXARRAY).toByte -> { in: DIS =>
         val r1 = codec1.unpack(in)
         val r2 = codec2.unpack(in)
         val r3 = codec3.unpack(in)

--- a/test/org.velvia/MsgPackTypeClassSpec.scala
+++ b/test/org.velvia/MsgPackTypeClassSpec.scala
@@ -51,6 +51,7 @@ class MsgPackTypeClassSpec extends FunSpec with Matchers {
 
     val intSeqCodec = new SeqCodec[Int]
     val strIntMapCodec = new MapCodec[String, Int]
+    val intSetCodec = new SetCodec[Int]
 
     it("should pack and unpack Seqs and Arrays") {
       val seq1 = Seq(1, 2, 3, 4, 5)
@@ -63,6 +64,11 @@ class MsgPackTypeClassSpec extends FunSpec with Matchers {
     it("should pack and unpack Maps") {
       val map = Map("apples" -> 1, "bears" -> -5, "oranges" -> 100)
       unpack(pack(map)(strIntMapCodec))(strIntMapCodec) should equal (map)
+    }
+
+    it("should pack and unpack Sets") {
+      val set = Set(1, 2, 3, 4, 5)
+      unpack(pack(set)(intSetCodec))(intSetCodec) should equal (set)
     }
   }
 

--- a/test/org.velvia/MsgPackTypeClassSpec.scala
+++ b/test/org.velvia/MsgPackTypeClassSpec.scala
@@ -4,6 +4,8 @@ import java.math.{BigDecimal, BigInteger}
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 
+import scala.util.Random
+
 class MsgPackTypeClassSpec extends FunSpec with Matchers {
   import org.velvia.msgpack._
   import org.velvia.msgpack.SimpleCodecs._
@@ -91,6 +93,34 @@ class MsgPackTypeClassSpec extends FunSpec with Matchers {
       unpack[JArray](pack(aray)) should equal (aray)
       unpack[JValue](pack(aray)) should equal (aray)
       unpack[JValue](pack(map)) should equal (map)
+    }
+  }
+
+  describe("tuple packing and unpacking") {
+    import org.velvia.msgpack.TupleCodecs._
+
+    it("should pack and unpack Tuple2") {
+      val codec2 = new TupleCodec2[Int, Int]
+      val tuple2 = (Random.nextInt(), Random.nextInt())
+      val unpacked2 = unpack(pack(tuple2)(codec2))(codec2)
+      unpacked2.getClass should equal (classOf[(Int, Int)])
+      unpacked2 should equal (tuple2)
+    }
+
+    it("should pack and unpack Tuple3") {
+      val codec3 = new TupleCodec3[Int, Int, Int]
+      val tuple3 = (Random.nextInt(), Random.nextInt(), Random.nextInt())
+      val unpacked3 = unpack(pack(tuple3)(codec3))(codec3)
+      unpacked3.getClass should equal (classOf[(Int, Int, Int)])
+      unpacked3 should equal (tuple3)
+    }
+
+    it("should pack and unpack Tuple4") {
+      val codec4 = new TupleCodec4[Int, Int, Int, Int]
+      val tuple4 = (Random.nextInt(), Random.nextInt(), Random.nextInt(), Random.nextInt())
+      val unpacked4 = unpack(pack(tuple4)(codec4))(codec4)
+      unpacked4.getClass should equal (classOf[(Int, Int, Int, Int)])
+      unpacked4 should equal (tuple4)
     }
   }
 }

--- a/test/org.velvia/MsgPackTypeClassSpec.scala
+++ b/test/org.velvia/MsgPackTypeClassSpec.scala
@@ -123,4 +123,44 @@ class MsgPackTypeClassSpec extends FunSpec with Matchers {
       unpacked4 should equal (tuple4)
     }
   }
+
+  describe("case class packing and unpacking") {
+    import org.velvia.msgpack.CaseClassCodecs._
+
+    it("should pack and unpack case class of 1 parameter") {
+      case class C1(a: Int)
+      val codec = new CaseClassCodec1[C1, Int](C1.apply, C1.unapply)
+      val c = C1(Random.nextInt())
+      val unpacked = unpack(pack(c)(codec))(codec)
+      unpacked.getClass should equal (classOf[C1])
+      unpacked should equal (c)
+    }
+
+    it("should pack and unpack case class of 2 parameters") {
+      case class C2(a1: Int, a2: Int)
+      val codec2 = new CaseClassCodec2[C2, Int, Int](C2.apply, C2.unapply)
+      val c = C2(Random.nextInt(), Random.nextInt())
+      val unpacked = unpack(pack(c)(codec2))(codec2)
+      unpacked.getClass should equal (classOf[C2])
+      unpacked should equal (c)
+    }
+
+    it("should pack and unpack case class of 3 parameters") {
+      case class C3(a1: Int, a2: Int, a3: Int)
+      val codec = new CaseClassCodec3[C3, Int, Int, Int](C3.apply, C3.unapply)
+      val c = C3(Random.nextInt(), Random.nextInt(), Random.nextInt())
+      val unpacked = unpack(pack(c)(codec))(codec)
+      unpacked.getClass should equal (classOf[C3])
+      unpacked should equal (c)
+    }
+
+    it("should pack and unpack case class of 4 parameters") {
+      case class C4(a1: Int, a2: Int, a3: Int, a4: Int)
+      val codec = new CaseClassCodec4[C4, Int, Int, Int, Int](C4.apply, C4.unapply)
+      val c = C4(Random.nextInt(), Random.nextInt(), Random.nextInt(), Random.nextInt())
+      val unpacked = unpack(pack(c)(codec))(codec)
+      unpacked.getClass should equal (classOf[C4])
+      unpacked should equal (c)
+    }
+  }
 }

--- a/test/org.velvia/MsgPackTypeClassSpec.scala
+++ b/test/org.velvia/MsgPackTypeClassSpec.scala
@@ -169,4 +169,17 @@ class MsgPackTypeClassSpec extends FunSpec with Matchers {
       unpacked should equal (c)
     }
   }
+
+  describe("bijection codecs") {
+    import org.velvia.msgpack.TransformCodecs._
+    import java.util.Date
+
+    it("should pack and unpack types that are in bijection with those having a codec") {
+      val codec = new TransformCodec[Date, Long](_.getTime, new Date(_))
+      val c = new Date
+      val unpacked = unpack(pack(c)(codec))(codec)
+      unpacked.getClass should equal (classOf[Date])
+      unpacked should equal (c)
+    }
+  }
 }

--- a/test/org.velvia/MsgPackUtilsSpec.scala
+++ b/test/org.velvia/MsgPackUtilsSpec.scala
@@ -1,10 +1,10 @@
 package org.velvia
 
 import java.io.{ByteArrayInputStream, DataInputStream}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.FunSpec
 
-class MsgPackUtilsSpec extends FunSpec with ShouldMatchers {
+class MsgPackUtilsSpec extends FunSpec with Matchers {
 
   val seqIntRow = (Seq(10, "AZ", "mobile"), 8)
 


### PR DESCRIPTION
As discussed [here](https://github.com/velvia/msgpack4s/issues/6), here is a PR for the Case Class codecs and Tuple codecs. It is not based on my work, I just took it from @dazebug fork. I only added back the settings for BinTray and the cross-compilation, which were taken out in that fork.

Moreover, I added a small `TransformCodec` that allows to (de)serialize a type `A` given a codec for a type `B`, and assuming one has two inverse functions `A => B` and `B => A`. This may be used to simplify the case class codecs, although this is not done yet.

If you accept the PR, would it be a problem for you to publish a new version? These new codecs are pretty useful to me